### PR TITLE
deps: update `bitflags` dependency to v2.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ targets = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.4"
 bit_field = "0.10"


### PR DESCRIPTION
Updates the `bitflags` dependency to the current major.minor release.